### PR TITLE
Automate pkg news update

### DIFF
--- a/.github/workflows/update_news.yml
+++ b/.github/workflows/update_news.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches: master
+  schedule:
+    - cron:  '0 0 * * *'
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - name: git config
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "gh-pages committer"
+
+      - name: Deploy package
+        run: Rscript -e 'build_news(outfile = "menu/updates.md")'
+
+      - name: Commit results
+        run: |
+          git clone https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git --branch history --single-branch
+          git add .
+          git commit -m 'Update pkg news'
+          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:history --force
+

--- a/build_news.R
+++ b/build_news.R
@@ -1,0 +1,30 @@
+build_news <- function(outfile) {
+
+  pavo_news <- readLines("https://raw.githubusercontent.com/rmaia/pavo/master/NEWS.md")
+  lightr_news <- readLines("https://raw.githubusercontent.com/ropensci/lightr/main/NEWS.md")
+
+  # We only display the changes for the two latest versions
+  pavo_news <- pavo_news[seq_len(grep("^# ", pavo_news)[3]-1)]
+  lightr_news <- lightr_news[seq_len(grep("^# ", lightr_news)[3]-1)]
+
+  # Decrease headings level by one
+  pavo_news <- gsub("^(#+)", "\\1#", pavo_news)
+  lightr_news <- gsub("^(#+)", "\\1#", lightr_news)
+
+  content <- paste(
+    "---",
+    "layout: page",
+    "title: Updates",
+    "---",
+    "",
+    "The most recent package updates:",
+    "",
+    paste(pavo_news, collapse = "\n"),
+    "---",
+    paste(lightr_news, collapse = "\n"),
+    sep = "\n"
+  )
+
+  write(content, outfile)
+
+}


### PR DESCRIPTION
This is a first draft to automate the update of packages news (`updates.md`) file. I have doubts about two points:

- Where should dev scripts be stored for a jekyll website?
- I'm not 100% about the process to commit the result to github. I took inspiration from [this file](https://raw.githubusercontent.com/lockedata/cransays/master/.github/workflows/cron.yml) but it's probably better to have a backup of this repo before you merge this.